### PR TITLE
Add helper notebook for scrape sensor

### DIFF
--- a/scrape-sensor-helper.ipynb
+++ b/scrape-sensor-helper.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scrape sensor helper\n",
+    "This is an alternative solution to get the `select` variable to set up a [`scrape` sensor](https://home-assistant.io/components/sensor.scrape/). You can still monitor the debug output but with this notebook it can be done in a more interactive way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from bs4 import BeautifulSoup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set a selector to identify the part you want to extract. Check [CSS selectors](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors) for further details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "URL = 'https://home-assistant.io/components/'\n",
+    "SELECTOR = 'a:nth-of-type(8)'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<a class=\"btn\" href=\"#all\">All (444)</a>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_html = requests.get(URL, timeout=5).text\n",
+    "raw_data = BeautifulSoup(raw_html, 'html.parser')\n",
+    "print(raw_data.select(SELECTOR))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [Web scraping notebooks](http://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/tree/master/) shown more details, especialy how the result can be handled. This helper is reduce to the  minium that's needed to get started with the [`scrape` sensor](https://home-assistant.io/components/sensor.scrape/)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Helper notebook to getting the `selector` to use with the [scrape sensor](https://github.com/home-assistant/home-assistant/pull/3841). It's the minimal version of the [web scraping notebook](https://github.com/home-assistant/home-assistant-notebooks/pull/4).