### PR TITLE
Update GETTING_STARTED.ipynb for updated HA database schema

### DIFF
--- a/GETTING_STARTED.ipynb
+++ b/GETTING_STARTED.ipynb
@@ -61,6 +61,7 @@
    "source": [
     "from collections import Counter, OrderedDict\n",
     "import json\n",
+    "import sqlalchemy\n",
     "\n",
     "from detective.time import time_category, sqlalch_datetime, localize, TIME_CATEGORIES\n",
     "\n",
@@ -71,7 +72,7 @@
     "# the first service call in a context, and not subsequent calls.\n",
     "context_processed = set()\n",
     "\n",
-    "for event in db.perform_query(\"SELECT * FROM events JOIN event_data ON events.data_id = event_data.data_id WHERE event_type = 'call_service' ORDER BY time_fired\"):\n",
+    "for event in db.perform_query(sqlalchemy.text(\"SELECT context_id_bin as context_id, event_data.shared_data as shared_data, from_unixtime(time_fired_ts) as time_fired FROM events LEFT JOIN event_data ON events.data_id = event_data.data_id  WHERE event_type_id = (select event_type_id from event_types where event_type = 'call_service') ORDER BY time_fired;\")):\n",
     "    entity_ids = None\n",
     "\n",
     "    # Skip if we have already processed an event that was part of this context\n",
@@ -266,18 +267,11 @@
     "    data=df[df['device_class'] == 'temperature'], \n",
     "    ax=ax);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -291,7 +285,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Newer HomeAssistant appears to need joins on some other tables, so modify the query for that. The timestamp is also a timestamp rather than datetime, so convert it to what we want.

Fixes: https://github.com/home-assistant/home-assistant-notebooks/issues/26

---

There are likely other getting started notebook issues that can be resolved as well.